### PR TITLE
Add Telegram contact action for HR manager

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,6 +338,10 @@
                                     <i data-lucide="mail" class="h-4 w-4"></i>
                                     <span>Надіслати e-mail</span>
                                 </a>
+                                <a href="https://t.me/Gala_HR_test_bot" class="inline-flex items-center gap-2 rounded-lg bg-sky-500 px-3 py-2 font-semibold text-white shadow hover:bg-sky-600 transition" target="_blank" rel="noopener noreferrer">
+                                    <i data-lucide="message-circle" class="h-4 w-4"></i>
+                                    <span>Написати в Telegram</span>
+                                </a>
                             </div>
                         </div>
                         <button type="button" class="mt-3 inline-flex items-center gap-2 text-sm font-medium text-amber-700 hover:underline" onclick="alert('Пам’ятка надіслана у ваш Telegram.');">


### PR DESCRIPTION
## Summary
- add a Telegram contact button to the HR manager card that matches existing action styling and uses a Lucide message icon

## Testing
- manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68cc72273cfc8329ae05449aa4cdc9cd