### PR TITLE
Add cashier training section to knowledge check page

### DIFF
--- a/index.html
+++ b/index.html
@@ -282,6 +282,155 @@
                         </div>
                     </article>
                 </div>
+                <section class="space-y-5 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+                    <div>
+                        <h4 class="text-lg font-semibold text-gray-800">Практичні тренажери та курси</h4>
+                        <p class="mt-1 text-sm text-gray-600">Виконуйте сценарії, що імітують реальну зміну, та одразу закріплюйте
+                            роботу з POS, податковою звітністю й стандартами безпечності.</p>
+                    </div>
+                    <div class="space-y-4">
+                        <article class="rounded-lg border border-gray-100 bg-amber-50/70 p-4">
+                            <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                                <div>
+                                    <h5 class="text-base font-semibold text-gray-800">Poster-дрил 1–2</h5>
+                                    <p class="mt-1 text-sm text-gray-600">Покрокова симуляція продажу: від відкриття зміни до повернення
+                                        коштів і закриття каси.</p>
+                                    <div class="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm font-medium text-amber-700">
+                                        <div class="flex items-center gap-1">
+                                            <i data-lucide="clock" class="h-4 w-4"></i>
+                                            <span>20 хвилин</span>
+                                        </div>
+                                        <a href="https://support.joinposter.com/uk" target="_blank" rel="noopener noreferrer"
+                                            class="inline-flex items-center gap-1 hover:underline">
+                                            <i data-lucide="external-link" class="h-4 w-4"></i>
+                                            <span>Poster Help Center</span>
+                                        </a>
+                                    </div>
+                                </div>
+                                <a href="https://support.joinposter.com/uk" target="_blank" rel="noopener noreferrer"
+                                    class="inline-flex items-center justify-center gap-2 rounded-lg bg-amber-500 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-amber-600 transition">
+                                    <i data-lucide="play" class="h-4 w-4"></i>
+                                    <span>Почати тренаж</span>
+                                </a>
+                            </div>
+                        </article>
+                        <article class="rounded-lg border border-gray-100 bg-white p-4">
+                            <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                                <div>
+                                    <h5 class="text-base font-semibold text-gray-800">PRRO / Z-звіт</h5>
+                                    <p class="mt-1 text-sm text-gray-600">Відпрацювання закриття зміни та формування Z-звіту з перевіркою
+                                        електронної стрічки й передачі даних на сервер ДПС.</p>
+                                    <div class="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm font-medium text-amber-700">
+                                        <div class="flex items-center gap-1">
+                                            <i data-lucide="clock" class="h-4 w-4"></i>
+                                            <span>15 хвилин</span>
+                                        </div>
+                                        <a href="https://cv.tax.gov.ua" target="_blank" rel="noopener noreferrer"
+                                            class="inline-flex items-center gap-1 hover:underline">
+                                            <i data-lucide="external-link" class="h-4 w-4"></i>
+                                            <span>cv.tax.gov.ua</span>
+                                        </a>
+                                    </div>
+                                </div>
+                                <a href="https://cv.tax.gov.ua" target="_blank" rel="noopener noreferrer"
+                                    class="inline-flex items-center justify-center gap-2 rounded-lg border border-amber-500 px-4 py-2 text-sm font-semibold text-amber-700 shadow-sm hover:bg-amber-50 transition">
+                                    <i data-lucide="file-text" class="h-4 w-4"></i>
+                                    <span>Почати тренаж</span>
+                                </a>
+                            </div>
+                        </article>
+                        <article class="rounded-lg border border-gray-100 bg-white p-4">
+                            <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                                <div>
+                                    <h5 class="text-base font-semibold text-gray-800">FIFO-квест</h5>
+                                    <p class="mt-1 text-sm text-gray-600">Інтерактивне сортування поставок і готової продукції за принципом
+                                        FIFO з перевіркою термінів придатності.</p>
+                                    <div class="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm font-medium text-amber-700">
+                                        <div class="flex items-center gap-1">
+                                            <i data-lucide="clock" class="h-4 w-4"></i>
+                                            <span>10 хвилин</span>
+                                        </div>
+                                        <a href="https://www.haccp.com.ua" target="_blank" rel="noopener noreferrer"
+                                            class="inline-flex items-center gap-1 hover:underline">
+                                            <i data-lucide="external-link" class="h-4 w-4"></i>
+                                            <span>HACCP Україна</span>
+                                        </a>
+                                    </div>
+                                </div>
+                                <a href="https://www.haccp.com.ua" target="_blank" rel="noopener noreferrer"
+                                    class="inline-flex items-center justify-center gap-2 rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-emerald-600 transition">
+                                    <i data-lucide="map" class="h-4 w-4"></i>
+                                    <span>Розпочати квест</span>
+                                </a>
+                            </div>
+                        </article>
+                        <article class="rounded-lg border border-gray-100 bg-white p-4">
+                            <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                                <div>
+                                    <h5 class="text-base font-semibold text-gray-800">HACCP-квест</h5>
+                                    <p class="mt-1 text-sm text-gray-600">Сценарій перевірки критичних точок контролю: від приймання товару
+                                        до видачі готових страв.</p>
+                                    <div class="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm font-medium text-amber-700">
+                                        <div class="flex items-center gap-1">
+                                            <i data-lucide="clock" class="h-4 w-4"></i>
+                                            <span>18 хвилин</span>
+                                        </div>
+                                        <a href="https://haccp.com.ua/knowledge-base" target="_blank" rel="noopener noreferrer"
+                                            class="inline-flex items-center gap-1 hover:underline">
+                                            <i data-lucide="external-link" class="h-4 w-4"></i>
+                                            <span>База знань HACCP</span>
+                                        </a>
+                                    </div>
+                                </div>
+                                <a href="https://haccp.com.ua/knowledge-base" target="_blank" rel="noopener noreferrer"
+                                    class="inline-flex items-center justify-center gap-2 rounded-lg border border-emerald-500 px-4 py-2 text-sm font-semibold text-emerald-600 shadow-sm hover:bg-emerald-50 transition">
+                                    <i data-lucide="shield" class="h-4 w-4"></i>
+                                    <span>Почати тренаж</span>
+                                </a>
+                            </div>
+                        </article>
+                    </div>
+                    <div class="rounded-lg border border-dashed border-amber-300 bg-amber-50/60 p-4">
+                        <h5 class="text-base font-semibold text-gray-800">Обов'язкові мікрокурси</h5>
+                        <p class="mt-1 text-sm text-gray-600">Пройдіть усі міні-курси, щоб підготуватися до сертифікації «Касир-1».</p>
+                        <ul class="mt-3 space-y-2 text-sm text-gray-700">
+                            <li class="flex items-start gap-2">
+                                <i data-lucide="check-circle" class="mt-0.5 h-4 w-4 text-emerald-500"></i>
+                                <span><span class="font-medium">Стандарти сервісу</span> — відео та тести, 12 хв.</span>
+                            </li>
+                            <li class="flex items-start gap-2">
+                                <i data-lucide="check-circle" class="mt-0.5 h-4 w-4 text-emerald-500"></i>
+                                <span><span class="font-medium">Безпечне користування обладнанням</span> — інтерактивні картки, 15 хв.</span>
+                            </li>
+                            <li class="flex items-start gap-2">
+                                <i data-lucide="check-circle" class="mt-0.5 h-4 w-4 text-emerald-500"></i>
+                                <span><span class="font-medium">Фінансова дисципліна касира</span> — практикум із касових ситуацій, 10 хв.</span>
+                            </li>
+                            <li class="flex items-start gap-2">
+                                <i data-lucide="check-circle" class="mt-0.5 h-4 w-4 text-emerald-500"></i>
+                                <span><span class="font-medium">Алгоритм дій у разі інциденту</span> — чек-ліст дій і короткий тест, 8 хв.</span>
+                            </li>
+                        </ul>
+                    </div>
+                </section>
+                <section class="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-gray-700 shadow-sm">
+                    <h4 class="text-lg font-semibold text-gray-800">Оцінювання та сертифікація «Касир-1»</h4>
+                    <p class="mt-1">Щоб отримати статус сертифікованого касира, виконайте всі вимоги нижче протягом останнього тижня адаптації.</p>
+                    <ul class="mt-3 space-y-2">
+                        <li class="flex items-start gap-2">
+                            <i data-lucide="graduation-cap" class="mt-0.5 h-4 w-4 text-amber-600"></i>
+                            <span><span class="font-medium">Підсумковий тест</span> — мінімум 85% правильних відповідей за результатами тематичних і підсумкових перевірок.</span>
+                        </li>
+                        <li class="flex items-start gap-2">
+                            <i data-lucide="check-square" class="mt-0.5 h-4 w-4 text-amber-600"></i>
+                            <span><span class="font-medium">Практичні чек-листи</span> — успішне виконання операцій у Poster, формування Z-звіту та контроль критичних точок за чек-листами наставника.</span>
+                        </li>
+                        <li class="flex items-start gap-2">
+                            <i data-lucide="award" class="mt-0.5 h-4 w-4 text-amber-600"></i>
+                            <span><span class="font-medium">Зворотний зв'язок наставника</span> — підтвердження готовності до самостійної зміни та рекомендації для подальшого розвитку.</span>
+                        </li>
+                    </ul>
+                </section>
                 <div class="rounded-xl border border-dashed border-gray-300 bg-white p-4 text-sm text-gray-500">
                     <p class="font-medium text-gray-700">Порада наставниці</p>
                     <p class="mt-1">Плануйте проходження одного тесту щодня та фіксуйте питання, які викликають труднощі, щоб обговорити їх на зустрічі з наставником.</p>


### PR DESCRIPTION
## Summary
- expand the knowledge check view with dedicated cards for Poster drills, PRRO/Z-report, FIFO, and HACCP scenarios
- list mandatory microcourses and add a certification checklist for the “Cashier-1” path

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cc724aaf308329ade53f9be9a822f2