### PR TITLE
Fix accordion toggle icon rotation after lucide replacement

### DIFF
--- a/index.html
+++ b/index.html
@@ -1654,7 +1654,7 @@
 
                 const contentId = toggle.getAttribute('aria-controls');
                 const content = contentId ? document.getElementById(contentId) : toggle.nextElementSibling;
-                const icon = toggle.querySelector('i');
+                const icon = toggle.querySelector('svg[data-lucide]') || toggle.querySelector('[data-lucide]');
                 const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
                 const newExpandedState = !isExpanded;
 


### PR DESCRIPTION
## Summary
- update the accordion toggle logic to target the Lucide-generated SVG icon so the rotate class applies correctly

## Testing
- Manual Playwright check confirming the accordion arrow rotates when expanded and collapses when closed

------
https://chatgpt.com/codex/tasks/task_e_68cc7718a8288329a3cb4296a4b2033b