### PR TITLE
Restore main progress bar on load

### DIFF
--- a/index.html
+++ b/index.html
@@ -474,8 +474,9 @@
                     progressState = JSON.parse(saved);
                 }
                 applyTheme();
-                renderPlan(); 
+                renderPlan();
                 renderQuizMenu();
+                updateMainProgressBar();
             }
             
             // --- THEME LOGIC ---


### PR DESCRIPTION
## Summary
- call updateMainProgressBar when restoring persisted progress so the main dashboard matches saved completion state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc8a821e6c8329a506e434e7466d72