### PR TITLE
Adjust quiz button disabled handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -686,11 +686,12 @@
                     const isCompleted = progressState.completedDays.includes(day);
 
                     const quizInfo = allQuizzes[quizId];
-                    const button = createElement('button', null, { 
-                        'data-quiz-id': quizId, 
-                        'class': 'w-full text-left p-4 rounded-lg font-semibold transition-colors flex justify-between items-center',
-                        'disabled': isLocked
+                    const button = createElement('button', null, {
+                        'data-quiz-id': quizId,
+                        'class': 'w-full text-left p-4 rounded-lg font-semibold transition-colors flex justify-between items-center'
                     });
+
+                    button.disabled = isLocked;
                     
                     const textDiv = createElement('div');
                     const title = createElement('span', quizInfo.title, {'class': 'block text-lg'});


### PR DESCRIPTION
## Summary
- set quiz menu buttons' disabled state via a property assignment so unlocked quizzes no longer receive a disabled attribute
- keep the quiz menu click handler using the button.disabled guard to ensure only unlocked quizzes start

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc8e8f15a48329828f33e784212d01