### PR TITLE
Fix quiz answer restoration for skipped questions

### DIFF
--- a/index.html
+++ b/index.html
@@ -764,8 +764,8 @@
                     });
                 });
 
-                if (userAnswers[currentQuestion] !== undefined) {
-                    const prevAnswer = userAnswers[currentQuestion];
+                const prevAnswer = userAnswers[currentQuestion];
+                if (prevAnswer !== undefined && prevAnswer !== null) {
                     const answerElement = answersContainer.children[prevAnswer];
                     if (answerElement) {
                         answerElement.querySelector('input').checked = true;
@@ -785,7 +785,7 @@
             function nextQuestion() {
                 const selectedAnswer = document.querySelector('input[name="answer"]:checked');
                 if (selectedAnswer) userAnswers[currentQuestion] = parseInt(selectedAnswer.value);
-                else if (userAnswers[currentQuestion] === undefined) userAnswers[currentQuestion] = null;
+                else userAnswers[currentQuestion] = undefined;
                 updateCurrentScore();
                 if (currentQuestion < currentQuizData.length - 1) { currentQuestion++; showQuestion(); } 
                 else showResults();


### PR DESCRIPTION
## Summary
- add a null check before restoring previous answers so unanswered questions remain unselected
- treat skipped answers as undefined rather than null to align with the restoration guard

## Testing
- manual Playwright browser test: skip the first quiz question, return to it, and confirm no option is selected

------
https://chatgpt.com/codex/tasks/task_e_68cc8f7377848329bfbcec91157dd6f8