### PR TITLE
Add modal image preview for product cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,58 @@
             border-width: 2px;
             transition: all 0.2s ease-in-out;
         }
+
+        .image-modal {
+            position: fixed;
+            inset: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background-color: rgba(0, 0, 0, 0.75);
+            z-index: 1000;
+            padding: 1.5rem;
+        }
+
+        .image-modal.hidden {
+            display: none;
+        }
+
+        .image-modal-content {
+            position: relative;
+            max-width: min(90vw, 640px);
+            max-height: 90vh;
+        }
+
+        .image-modal-content img {
+            width: 100%;
+            height: auto;
+            max-height: 90vh;
+            border-radius: 0.75rem;
+            box-shadow: var(--shadow);
+        }
+
+        .image-modal-close {
+            position: absolute;
+            top: 0.5rem;
+            right: 0.5rem;
+            width: 2.5rem;
+            height: 2.5rem;
+            border: none;
+            border-radius: 9999px;
+            background-color: rgba(0, 0, 0, 0.65);
+            color: #ffffff;
+            font-size: 1.5rem;
+            line-height: 1;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .image-modal-close:focus {
+            outline: 2px solid var(--primary);
+            outline-offset: 2px;
+        }
     </style>
 </head>
 <body class="antialiased">
@@ -442,8 +494,34 @@
         </main>
     </div>
 
+    <div id="image-modal" class="image-modal hidden" role="dialog" aria-modal="true">
+        <div class="image-modal-content">
+            <button id="image-modal-close" type="button" class="image-modal-close" aria-label="Закрити зображення">&times;</button>
+            <img id="image-modal-image" src="" alt="">
+        </div>
+    </div>
+
     <script src="https://unpkg.com/lucide@latest"></script>
     <script>
+        let imageModal = null;
+        let imageModalImage = null;
+
+        function openImageModal(imageSrc, altText = '') {
+            if (!imageModal || !imageModalImage || !imageSrc) return;
+
+            imageModalImage.src = imageSrc;
+            imageModalImage.alt = altText || 'Зображення продукту';
+            imageModal.classList.remove('hidden');
+        }
+
+        function closeImageModal() {
+            if (!imageModal || !imageModalImage) return;
+
+            imageModal.classList.add('hidden');
+            imageModalImage.src = '';
+            imageModalImage.alt = '';
+        }
+
         // --- UTILITY FUNCTIONS ---
         function createElement(tag, content, attributes = {}) {
             const element = document.createElement(tag);
@@ -458,6 +536,28 @@
         // --- APP INITIALIZATION ---
         document.addEventListener('DOMContentLoaded', () => {
             lucide.createIcons();
+
+            imageModal = document.getElementById('image-modal');
+            imageModalImage = document.getElementById('image-modal-image');
+            const imageModalCloseButton = document.getElementById('image-modal-close');
+
+            if (imageModalCloseButton) {
+                imageModalCloseButton.addEventListener('click', closeImageModal);
+            }
+
+            if (imageModal) {
+                imageModal.addEventListener('click', (event) => {
+                    if (event.target === imageModal) {
+                        closeImageModal();
+                    }
+                });
+            }
+
+            document.addEventListener('keydown', (event) => {
+                if (event.key === 'Escape' && imageModal && !imageModal.classList.contains('hidden')) {
+                    closeImageModal();
+                }
+            });
 
             // --- STATE MANAGEMENT ---
             let progressState = {
@@ -484,6 +584,8 @@
                         'class': 'h-40 w-full object-cover'
                     });
                     card.appendChild(image);
+                    card.addEventListener('click', () => openImageModal(product.image, product.name || 'Продукт'));
+                    card.style.cursor = 'pointer';
                 }
 
                 const content = createElement('div', null, { 'class': 'p-4 flex flex-col flex-1' });
@@ -491,16 +593,6 @@
                     'class': 'font-semibold text-base mb-3',
                     'style': 'color: var(--card-foreground);'
                 }));
-
-                if (product.url) {
-                    content.appendChild(createElement('a', 'Переглянути', {
-                        href: product.url,
-                        target: '_blank',
-                        rel: 'noopener noreferrer',
-                        'class': 'mt-auto inline-flex items-center justify-center px-4 py-2 rounded-md font-medium transition-colors',
-                        'style': 'background-color: var(--primary); color: var(--primary-foreground);'
-                    }));
-                }
 
                 card.appendChild(content);
                 return card;


### PR DESCRIPTION
## Summary
- add markup, styles, and helpers for an image modal overlay
- remove the external product link and open the modal when a card image is clicked

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cce62ea0ac8329b66ff6b5e322f4a7