### PR TITLE
Load products on first visit

### DIFF
--- a/index.html
+++ b/index.html
@@ -703,6 +703,7 @@
                 'plan-page': 'План Навчання', 'quiz-page': 'Перевірка Знань',
                 'contacts-page': 'Корисні Контакти', 'checklists-page': 'Щоденні Чек-листи'
             };
+            let productsLoaded = false;
 
             const showPage = (pageId) => {
                 mainPage.style.display = 'none';
@@ -712,6 +713,10 @@
                     activePage.style.display = 'block';
                     headerTitle.textContent = pageTitles[pageId] || 'Деталі';
                     backButton.classList.remove('invisible');
+                    if (pageId === 'products-page' && !productsLoaded) {
+                        loadProducts();
+                        productsLoaded = true;
+                    }
                 }
             };
 
@@ -1036,7 +1041,6 @@
             });
 
             // Initial Load
-            loadProducts();
             loadProgress();
         });
     </script>


### PR DESCRIPTION
## Summary
- add a productsLoaded flag to ensure product data loads only on the first visit to the catalog page
- remove the eager loadProducts() call from the initial load routine to prevent redundant fetches

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccee809ba48329989df9f55ca16daf