### PR TITLE
Connect quiz navigation buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -1041,15 +1041,16 @@
                 if (selectedAnswer) userAnswers[currentQuestion] = parseInt(selectedAnswer.value);
                 else userAnswers[currentQuestion] = undefined;
                 updateCurrentScore();
-                if (currentQuestion < currentQuizData.length - 1) { currentQuestion++; showQuestion(); } 
-                else showResults();
+                if (currentQuestion < currentQuizData.length - 1) { currentQuestion++; showQuestion(); }
+                else { showResults(); updateNavigationButtons(); }
             }
-            
+
             function prevQuestion() {
                 const selectedAnswer = document.querySelector('input[name="answer"]:checked');
                 if (selectedAnswer) userAnswers[currentQuestion] = parseInt(selectedAnswer.value);
                 updateCurrentScore();
                 if(currentQuestion > 0) { currentQuestion--; showQuestion(); }
+                else updateNavigationButtons();
             }
 
             function updateNavigationButtons() {
@@ -1083,6 +1084,12 @@
 
             function restartQuizState() { currentQuestion = 0; score = 0; userAnswers = []; }
             function showTestMenu() { quizStartScreen.classList.remove('hidden'); quizMainScreen.classList.add('hidden'); }
+
+            const nextQuestionButton = document.getElementById('next-question');
+            if (nextQuestionButton) nextQuestionButton.addEventListener('click', nextQuestion);
+
+            const prevQuestionButton = document.getElementById('prev-question');
+            if (prevQuestionButton) prevQuestionButton.addEventListener('click', prevQuestion);
 
             document.getElementById('back-to-tests').addEventListener('click', showTestMenu);
             document.getElementById('restart-quiz').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- attach click handlers to the quiz navigation buttons so they trigger the existing navigation logic
- ensure the navigation buttons update correctly when stepping forward, backward, or finishing the quiz

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccf43266e8832987d9d1af6c48a8ff